### PR TITLE
Consolidate cost information and image into a single Slack message

### DIFF
--- a/slack.go
+++ b/slack.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"bytes"
+	"fmt"
+
 	"github.com/slack-go/slack"
 )
 
@@ -9,28 +11,19 @@ func postToSlack(cfg *Config, text string, graphBuf *bytes.Buffer) error {
 	api := slack.New(cfg.SlackBotToken)
 
 	if !dryRun() {
-		opts := []slack.MsgOption{
-			slack.MsgOptionText(text, false),
-		}
-
-		_, _, err := api.PostMessage(
-			cfg.SlackChannelId,
-			opts...,
-		)
-
-		_, err = api.UploadFileV2(
+		_, err := api.UploadFileV2(
 			slack.UploadFileV2Parameters{
-				Reader:         graphBuf,
+				Reader:         bytes.NewReader(graphBuf.Bytes()),
 				FileSize:       graphBuf.Len(),
 				Filename:       "daily_costs.png",
-				InitialComment: "アカウント別の日次料金(90日分)",
 				Channel:        cfg.SlackChannelId,
+				InitialComment: text,
 			})
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to upload file: %w", err)
 		}
 
-		return err
+		return nil
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

This PR consolidates the cost information text and image graph into a single Slack message instead of posting them separately.

## Changes

- Modified `postToSlack` function in `slack.go` to use `UploadFileV2` with `InitialComment` parameter
- Removed separate `PostMessage` call for text content
- Text and image are now posted together as a single message using `InitialComment`

## Before

- Text was posted via `PostMessage`
- Image was posted separately via `UploadFileV2`
- Resulted in two separate messages in Slack

## After

- Text and image are posted together in a single message
- Uses `UploadFileV2` with `InitialComment` to include text with the image upload
- Results in one consolidated message in Slack
